### PR TITLE
Update: Add IPFS downloads and uploads considerations

### DIFF
--- a/bitcoinfiles.md
+++ b/bitcoinfiles.md
@@ -13,16 +13,16 @@ James Cramer
 ## Acknowledgements
 Mark Lundeberg, for further simplifying the protocol
 
-Jonald Fyookball, for various comments and considerations 
+Jonald Fyookball, for various comments and considerations
 
 Calin Culianu, for EC SLP Wallet implementation assistance
 
-MatterBCH, for suggesting IPFS metadata in file uploads
+Attila Aros, for suggesting IFPS metadata in file uploads
 
 hapticpilot, for IPFS and URI formatting suggestions
 
 ## 1. Introduction
-The following presents a simple protocol for adding files to the Bitcoin Cash blockchain.  The protocol allows for creating immutable hyperlinks pointing to on-chain and off-chain data storage providers.  The motivation for this protocol was driven by lack of reliable and anonymous file upload web services that have a good API for creating a public shareable file URL.  
+The following presents a simple protocol for adding files to the Bitcoin Cash blockchain.  The protocol allows for creating immutable hyperlinks pointing to on-chain and off-chain data storage providers.  The motivation for this protocol was driven by lack of reliable and anonymous file upload web services that have a good API for creating a public shareable file URL.
 
 The original purpose of such a protocol is to facilitate the simple uploading of JSON documents for an SLP token's GENESIS transaction. BFP is a separate protocol from SLP Tokens, but its design uses a DAG to link file chunks and metadata together over multiple transactions so in that way it is similar to SLP tokens.
 
@@ -68,7 +68,7 @@ It is recommended that an initial funding transaction be created (as shown in th
 
 #### 2.2.2 Procedure for downloading on-chain files
 
-Files are located on the blockchain using the transaction id of the file's metadata OP_RETURN message. In order to download the full file content the software implementation simply needs to follow the following steps: 
+Files are located on the blockchain using the transaction id of the file's metadata OP_RETURN message. In order to download the full file content the software implementation simply needs to follow the following steps:
 
 1. Download the file's metadata transaction
 2. Parse for Metadata OP_RETURN message located at the first output (i.e., vout:0) within that transaction
@@ -84,11 +84,87 @@ Files are located on the blockchain using the transaction id of the file's metad
 Immutable hyperlinks to files stored off-chain can be created using Type 0x02 BFP message.  The file's URI shall be used to identify the external storage device and the relative location of the file on that device.
 
 1. **Metadata Transaction OP_RETURN:** A single transaction containing an OP_RETURN message at output index 0 (i.e., vout:0) shall be provided.  The required format is:
-   -  `OP_RETURN <lokad_id_int = 'BFP\x00'> <bfp_msg_type = 0x02> <file_uri_utf8>  <filename_no_extension_utf8*> <file_extension_utf8*> <size_bytes_int*> <file_sha256_int*> `
+   -  `OP_RETURN <lokad_id_int = 'BFP\x00'> <bfp_msg_type = 0x02> <file_uri_utf8> <file_uri_metadata_utf8> <filename_no_extension_utf8*> <file_extension_utf8*> <size_bytes_int*> <file_sha256_int*> `
 
 #### 2.3.2 Procedure for downloading off-chain files from hyperlinks
 
 Downloading files should be handled per the requirements for each specific off chain storage system.  The requirements should be deterministic based on the provided URI.
+
+#### 2.3.2.1 IPFS downloads
+
+[IPFS](https://ipfs.io) is a system for storing and distributing files. The key benefit of IPFS is decentralization and consistent addressability.
+
+An IPFS hash can be included to make it easier for users to download content more efficiently, instead of querying for chunk transactions on the blockchain. Since the IPFS hash is uniquely determined by the file content (and a few other settings explained below shortly), then this is a perfect and accurate replacement for the download operation.
+
+- User agent *may* choose to query an IPFS gateway of their choice after retrieving the metadata transaction.
+
+There are numerous public gateways available that would be suitable options for resolving IPFS links.
+
+For example, if a metadata transaction contained the IPFS hash `Qmc5gCcjYypU7y28oCALwfSvxCBskLuPKWpK4qpterKC7z`, then the user agent could download this file from an IPFS gateway via a URL of the form: `https://gateway.ipfs.io/ipfs/Qmc5gCcjYypU7y28oCALwfSvxCBskLuPKWpK4qpterKC7z`
+
+- User browser agent *may* choose to query an IPFS swarm directly instead using a pure Javascript/Browser implementation such as [js-ipfs](https://github.com/ipfs/js-ipfs).
+
+- User agent *may* to set a time limit for how long they are willing to wait for IPFS to resolve the content, and instead opt for retrieving the individual chunk transactions to serve their request instead.
+
+If the content is not retrievable or not found on IPFS, then the user *may* re-upload the content to IPFS after retrieving the content bytes from the transaction chunks. The next section highlights the considerations for performing an upload as there are some IPFS specific flags that need to be set consistently to arrive at the same IPFS hash.
+
+#### 2.3.2.2 IPFS uploads
+
+IPFS hashes are uniquely determined by a few parameters, not simply the sha256 hash of the file content. This is unavoidable since IPFS provides different storage options, identifier versioning, and also needs some flexibility for the future.
+
+IPFS options (which determine the IPFS hash created with `ipfs add -n`)
+* Chunking algorithm (--chunker option)
+* DAG format (--trickle option)
+* CID version (--cid-version option)
+* Hashing algorithm (--hash option)
+[Source](https://discuss.ipfs.io/t/how-to-calculate-file-directory-hash/777/4)
+
+**Defaults**
+
+--chunker
+
+Default: `size-262144` (1024*256)
+
+--trickle
+
+Default: false
+
+--cid-version
+
+Default: CIDv0 (Starts with 'Qm...')
+
+Note: this is a [self-describing format](https://github.com/ipld/cid#versions) and therefore can be uniquely determined by looking at the hash prefix
+
+--hash
+
+Default: sha256
+
+At the time of writing, the latest version of IPFS is `ipfs version 0.4.17` and the defaults described above are accurate for this version.
+
+It is *recommended* that user agents calculate the IPFS hash for a file using `ipfs add -n` (and the necessary parameters). This will ensure maximum compatibility for other users, in the event that the content has been garbaged collected from all live IPFS nodes and a user wishes to make the content available again under the same IPFS hash.
+
+The facilite being able to easily recreate the IPFS hash, we are *recommending* that users include the optional `<file_uri_metadata_utf8>` to inform clients what IPFS hashing options were used.
+
+The parameter `<file_uri_metadata_utf8>` is a tab delimited utf8 string of the form:
+
+`<ipfs_options_info_version|<known_working_ipfs_str_version>|<chunker_str_utf8>|<trickle_bool_int>|<hash>|`
+
+Note: The --cid-version is not included, since it is a self-describing format and can be identified from the IPFS hash itself.
+
+`ipfs_options_info_version` is a microformat, here set to `1` to be used later in the event we want to change the contents of this tab delimited string.
+
+Examples:
+
+` `: Any empty string is considered to use the default (best effort guesses of what settings were used)
+`||||`: This means it is not provided (use defaults, best effort guesses).
+`1||||`: This means it is not provided (use defaults, best effort guesses).
+`1|0.4.17||||`: Version is set, but agent did not provide any additional information
+`1|0.4.17|size-262144||`: Version is set, and chunker option set
+`1|0.4.17|size-262144|1|`: Version is set, chunker option set, and trickle is set to true
+`1||size-262144|0|sha256`: Version unknown, chunker option set, trickle is set to false, and sha256 is the hashing algorithm.
+
+It is *recommended** that the user agent sets all the command line options for `ipfs add -n` and then provides these values here explicitly to enable others to create the precise hash.  On the other hand, the defaults are not expected to change anytime soon, therefore as long as the user is using an unmodified version of ipfs, then they should be able to easily obtain the same hash.
+
 
 ### 2.4 Folders (Message Type = 0x03)
 
@@ -96,10 +172,10 @@ A folder message type stores one or more transaction hash/ids belonging to other
 
 #### 2.4.1 Rules for creating folders
 
-1. **Metadata Transaction OP_RETURN:** The last and final signed transaction for the file must contain an OP_RETURN message containing metadata located at output index 0 (i.e., vout:0).  The required format is: 
+1. **Metadata Transaction OP_RETURN:** The last and final signed transaction for the file must contain an OP_RETURN message containing metadata located at output index 0 (i.e., vout:0).  The required format is:
    * `OP_RETURN <lokad_id_int = 'BFP\x00'> <bfp_msg_type = 0x03> <list_page_count> <folder_name*>  <folder_description*> <txid_0_int> ... <txid_i_int*> ... <txn_id_n>`
 
-2. **Transactions List Page OP_RETURN:** Since a list of transaction hashes may be as long as required additional OP_RETURN space may need to be provided.  The number of list pages should be specified to be greater than 1 within the metadata OP_RETURN in order to indicate 
+2. **Transactions List Page OP_RETURN:** Since a list of transaction hashes may be as long as required additional OP_RETURN space may need to be provided.  The number of list pages should be specified to be greater than 1 within the metadata OP_RETURN in order to indicate
 3. **List Page Transaction Baton:**  For any list page transaction a baton is used so that a reference pointer can be created to the file's list page or folder metadata transaction. Output index 1 (i.e., vout: 1) shall contain the UTXO dust that shall be spent in the next transaction as the first input (i.e., vin: 0).  The next transaction after a list page transaction can be either another list page transaction OR at the folder's final metadata transaction.
 
 #### 2.4.2 Procedures for discovering files within a folder
@@ -109,7 +185,7 @@ The rules for determining the files in a folder are simple.  An implementation s
 ## 3. OP_RETURN Syntax and Format Requirements
 
 1. Data fields are represented using the field's name within angle brackets (i.e.,  `<some_field_name>` )
-2. Data push opcodes are not presented above. For each field an appropriate data push code shall be utilized.  Opcodes rules for data pushes 
+2. Data push opcodes are not presented above. For each field an appropriate data push code shall be utilized.  Opcodes rules for data pushes
 3. The data encoding for each variable is included as the final part of the variable name.
 4. Optional fields are indicated using `*` at the end of the field's name, and can be left empty using the push code `0x4c 0x00`, or `0x4d 0x00 0x00`, or `0x4e 0x00 0x00 0x00 0x00`.
 5. Bitcoin script allows a given byte array to be pushed in various ways, and we allow this in SLP as well. For example, it is valid to push a 4-byte chunk (like the Lokad ID) in four different ways: 0x04 [chunk], 0x4c 0x04 [chunk], 0x4d 0x04 0x00 [chunk], or 0x4e 0x04 0x00 0x00 0x00 [chunk].
@@ -117,7 +193,7 @@ The rules for determining the files in a folder are simple.  An implementation s
 
 ## 4. File URI Prefixes
 
-This part of the specification in not a protocol rule and is only a recommendation for an improved user experience.  It is recommended that a prefix of "bitcoinfile:" be used for the transaction hash/id representing either on-chain or off-chain file.  In the future the concept of folders can be added to this protocol and the prefix of "bitcoinfiles:" should be used.  
+This part of the specification in not a protocol rule and is only a recommendation for an improved user experience.  It is recommended that a prefix of "bitcoinfile:" be used for the transaction hash/id representing either on-chain or off-chain file.  In the future the concept of folders can be added to this protocol and the prefix of "bitcoinfiles:" should be used.
 
 For example:
 
@@ -129,7 +205,7 @@ The usage of a transaction id prefix shall have no impact on the protocol rules,
 
 ## 5. Other Considerations
 
-1. Network rules currently limit the number of chained transactions to 25 per block, this limits the data throughput of this protocol to slightly more than 5kB files.  Implementations will need consider the number of chained transactions a UTXO may already has before creating a file upload.  For example, the file upload may be limited to fewer than 25 transactions if the user has made several transactions prior to the file uploads within the same block height. 
+1. Network rules currently limit the number of chained transactions to 25 per block, this limits the data throughput of this protocol to slightly more than 5kB files.  Implementations will need consider the number of chained transactions a UTXO may already has before creating a file upload.  For example, the file upload may be limited to fewer than 25 transactions if the user has made several transactions prior to the file uploads within the same block height.
 
 2. Set a limit for file upload sizes to encourage wise use of blockchain space
 

--- a/bitcoinfiles.md
+++ b/bitcoinfiles.md
@@ -8,7 +8,7 @@
 ### URL: [bitcoinfiles.com](bitcoinfiles.com)
 
 ## Authors
-James Cramer
+James Cramer, Attila Aros
 
 ## Acknowledgements
 Mark Lundeberg, for further simplifying the protocol
@@ -16,8 +16,6 @@ Mark Lundeberg, for further simplifying the protocol
 Jonald Fyookball, for various comments and considerations
 
 Calin Culianu, for EC SLP Wallet implementation assistance
-
-Attila Aros, for suggesting IFPS metadata in file uploads
 
 hapticpilot, for IPFS and URI formatting suggestions
 
@@ -84,7 +82,7 @@ Files are located on the blockchain using the transaction id of the file's metad
 Immutable hyperlinks to files stored off-chain can be created using Type 0x02 BFP message.  The file's URI shall be used to identify the external storage device and the relative location of the file on that device.
 
 1. **Metadata Transaction OP_RETURN:** A single transaction containing an OP_RETURN message at output index 0 (i.e., vout:0) shall be provided.  The required format is:
-   -  `OP_RETURN <lokad_id_int = 'BFP\x00'> <bfp_msg_type = 0x02> <file_uri_utf8> <file_uri_metadata_utf8> <filename_no_extension_utf8*> <file_extension_utf8*> <size_bytes_int*> <file_sha256_int*> `
+   -  `OP_RETURN <lokad_id_int = 'BFP\x00'> <bfp_msg_type = 0x02> <file_uri_utf8> <filename_no_extension_utf8*> <file_extension_utf8*> <size_bytes_int*> <file_sha256_int*> `
 
 #### 2.3.2 Procedure for downloading off-chain files from hyperlinks
 
@@ -143,27 +141,35 @@ At the time of writing, the latest version of IPFS is `ipfs version 0.4.17` and 
 
 It is *recommended* that user agents calculate the IPFS hash for a file using `ipfs add -n` (and the necessary parameters). This will ensure maximum compatibility for other users, in the event that the content has been garbaged collected from all live IPFS nodes and a user wishes to make the content available again under the same IPFS hash.
 
-The facilite being able to easily recreate the IPFS hash, we are *recommending* that users include the optional `<file_uri_metadata_utf8>` to inform clients what IPFS hashing options were used.
+The facilite being able to easily recreate the IPFS hash, we are *recommending* that users include additional/optional URI query params to inform clients what IPFS hashing options were used.
 
-The parameter `<file_uri_metadata_utf8>` is a tab delimited utf8 string of the form:
+Query format example:
+`Qmc5gCcjYypU7y28oCALwfSvxCBskLuPKWpK4qpterKC7z?ver=<string>&chunker=<string>&trickle=<int>&hash=<string>`
 
-`<ipfs_options_info_version|<known_working_ipfs_str_version>|<chunker_str_utf8>|<trickle_bool_int>|<hash>|`
-
-Note: The --cid-version is not included, since it is a self-describing format and can be identified from the IPFS hash itself.
-
-`ipfs_options_info_version` is a microformat, here set to `1` to be used later in the event we want to change the contents of this tab delimited string.
+It is *recommended** that the user agent sets these parameters for all the command line options for `ipfs add -n` and then provides these values  explicitly to enable others to create the precise hash.  On the other hand, the defaults are not expected to change anytime soon, therefore as long as the user is using an unmodified version of ipfs, then they should be able to easily obtain the same hash.
 
 Examples:
 
-` `: Any empty string is considered to use the default (best effort guesses of what settings were used)
-`||||`: This means it is not provided (use defaults, best effort guesses).
-`1||||`: This means it is not provided (use defaults, best effort guesses).
-`1|0.4.17||||`: Version is set, but agent did not provide any additional information
-`1|0.4.17|size-262144||`: Version is set, and chunker option set
-`1|0.4.17|size-262144|1|`: Version is set, chunker option set, and trickle is set to true
-`1||size-262144|0|sha256`: Version unknown, chunker option set, trickle is set to false, and sha256 is the hashing algorithm.
+Only IPFS version is defined (default and best effort to attempt to recreate hash)
+`Qmc5gCcjYypU7y28oCALwfSvxCBskLuPKWpK4qpterKC7z?ver=0.4.17`
+- ver: `0.4.17` is the known working version of IPFS that hash was created with
 
-It is *recommended** that the user agent sets all the command line options for `ipfs add -n` and then provides these values here explicitly to enable others to create the precise hash.  On the other hand, the defaults are not expected to change anytime soon, therefore as long as the user is using an unmodified version of ipfs, then they should be able to easily obtain the same hash.
+Just the IPFS hash is provided (default and best effort to attempt to recreate hash)
+`Qmc5gCcjYypU7y28oCALwfSvxCBskLuPKWpK4qpterKC7z`
+
+All options explicitly defined: (will yield the same hash if all options are matching)
+`Qmc5gCcjYypU7y28oCALwfSvxCBskLuPKWpK4qpterKC7z?ver=0.4.17&chunker=size-262144&trickle=0&hash=sha256`
+- ver: `0.4.17` is the known working version of IPFS that hash was created with
+- chunker: `size-262144` is the default value
+- trickle: `0` is disabled by default
+- hash: `sha256` is the default algorithm
+
+All options explicitly defined except chunker: (will yield the same hash if all options are matching)
+`Qmc5gCcjYypU7y28oCALwfSvxCBskLuPKWpK4qpterKC7z?ver=0.4.17&trickle=1&hash=sha256`
+- ver: `0.4.17` is the known working version of IPFS that hash was created with
+- trickle: `1` is disabled by default
+
+The user agent can infer that `chunker` and `hash` should be the default values as of version 0.4.17 and to enable `trickle`.
 
 
 ### 2.4 Folders (Message Type = 0x03)


### PR DESCRIPTION
@jcramer Here is the PR as requested.  Would love to hear your guys' feedback and suggestions.

Changes:

- Added details for operation of uploading/download of content stored in IPFS
- Documented `file_uri_utf8`option for IPFS
- Added optional `file_uri_metadata_utf8` to describe the URI external storage type (micro format within 
- Attribution from `MatterBCH` changed, as that is Matter's reddit username that I used. [Reference](https://www.reddit.com/r/btc/comments/9i81ta/announcing_bitcoin_files_protocol_bfp_version_1/e6l6qst/)

Really curious how we can improve this last option `file_uri_metadata_utf8` as this not my favorite part, but I think it is valuable for posterity for the files stored and the protocol itself. It is optional, and clients can in theory reconstruct this with tuning the options until they arrive at it. This is why we recommend to not change any of the ipfs settings when creating the hash.


Also here are some comments and questions after reviewing the specification that may be helpful.

-----

**Additional Notes/Questions:**

- There is a funding TX required in a chain of utxos. If the user calculates the fee incorrectly, during network congestion (yes, this should "never" happen), then they may not be able to complete uploading all their chunks in a timely fashion. This can be mitigated later on with a mining node upgrade, see next few comments.

- In order to support larger files, then the max chain of unconfirmed transactions must be increased, or the user must be willing to wait for more block confirmations in turn and therefore the upload may take hours, or even days (depending on file size).  Related to error`too-long-mempool-chain`

Nonetheless, this is a very elegant and predictable solution to optimizing for *storage space* since no chunk counter and/or reference `txid` needs to be be embedded (and therefore no space of the OP_RETURN is lost for the data chunks).  It will be easier to optimize the max unconfirmed chained transactions than it is to potentially lose 34 Bytes+ for every OP_RETURN referencing/chunk counters.

- What is the difference between `<size_bytes_int*>`  and  `<chunk_X_data_bytes*>`?   **Answer:** `size_bytes_int` is the total size of the file, whereas `chunk_X_data_bytes` is the bytes of the chunk contained in the same transaction as the metadata. An observation here is that the `size_bytes_int` is technically redundant, but best practice should be to provide it here too, since there is a field for it.

- How would data retrieval work if there are many chunk transactions? Is there a way something like bitdb.network could return all of the chunks with a single query?

- Perhaps this could use more clarification: 

>If the file includes 1 or more data chunks *AND* the chunk data is not included in this metadata transaction then first input to this transaction (i.e., vin: 0) shall be used to locate the first data chunk.

The vout1 of the metadata transaction points to the first chunk, correct?


- Note: `file_extension_utf8` should be adequate to determine file type. It is preferable to use a file extension over a full MIME type to conserve space.

